### PR TITLE
Bring tooling up-to-date

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,1 @@
+--relative

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,16 @@
+AllCops:
+  TargetRubyVersion: 1.9
+  Exclude:
+    - 'modules/**/*'
+    - 'pkg/**/*'
+    - 'spec/fixtures/**/*'
+    - 'vendor/**/*'
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,15 @@ cache:
 env:
   global:
     - LIBRARIAN_PUPPET_TMP="$HOME/librarian-puppet"
-  matrix:
-    - PUPPET_VERSION="3.4.3"    # Version installed on Trusty
-    - PUPPET_VERSION="~> 3.8.0" # Latest 3.x version
+matrix:
+  include:
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 3"
+    - rvm: 2.1.9
+      env: PUPPET_VERSION="~> 4"
 
-script: bundle exec rake test
+before_install:
+  - gem update bundler
+
+script:
+  - bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,12 @@ source 'https://rubygems.org'
 group :test do
   gem 'rake'
 
-  puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 3.0.0','< 4.0']
-  gem 'puppet', puppetversion
+  gem 'puppet', ENV['PUPPET_VERSION'] || '>= 3.4.0'
 
   gem 'librarian-puppet'
   gem 'metadata-json-lint'
   gem 'puppetlabs_spec_helper'
   gem 'rspec-puppet-facts'
+
+  gem 'rubocop', RUBY_VERSION < '2.0' ? '~> 0.41.2' : '~> 0.47.1'
 end

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
-#^syntax detection
 
-forge "https://forgeapi.puppetlabs.com"
+forge 'https://forgeapi.puppetlabs.com'
 
 # use dependencies defined in metadata.json
 metadata

--- a/Rakefile
+++ b/Rakefile
@@ -1,37 +1,24 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'metadata-json-lint/rake_task'
+require 'rubocop/rake_task'
 
 task :librarian_spec_prep do
   sh 'librarian-puppet install --path=spec/fixtures/modules/'
 end
 task :spec_prep => :librarian_spec_prep
 
-# Override puppetlabs_spec_helper's default lint settings
-# * Don't want to ignore so many tests
-# * Don't want to run lint on upstream modules
 Rake::Task[:lint].clear
 PuppetLint::RakeTask.new(:lint) do |config|
   config.fail_on_warnings = true
-  config.disable_checks = [
-      '80chars',
-      'class_inherits_from_params_class',
-      'autoloader_layout',
-  ]
-  config.ignore_paths = ["vendor/**/*.pp", "spec/**/*.pp", "modules/**/*.pp"]
+  # Don't want to run lint on upstream modules
+  config.ignore_paths = ['vendor/**/*.pp', 'spec/**/*.pp', 'modules/**/*.pp']
 end
 
-# Coverage from puppetlabs_spec_helper requires rcov which doesn't work in
-# anything since Ruby 1.8.7
-Rake::Task[:coverage].clear
-
-# Remove puppetlabs_spec_helper's metadata and validate tasks
-Rake::Task[:validate].clear
-Rake::Task[:metadata].clear
-
-desc "Run syntax, lint, metadata and spec tests."
+desc 'Run syntax, lint, metadata and spec tests.'
 task :test => [
   :syntax,
   :lint,
   :metadata_lint,
   :spec,
+  :rubocop,
 ]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "praekeltfoundation-docker_firewall",
-  "version": "0.1.0",
+  "version": "0.2.0-dev",
   "author": "Jamie Hewland",
   "summary": "Simplifies management of iptables rules when running Docker",
   "license": "BSD-3-Clause",
@@ -10,20 +10,26 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.2.0"
+      "version_requirement": ">= 4.2.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 1.7.0"
+      "version_requirement": ">= 1.7.0 < 2.0.0"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.4.0 < 4.0.0"
+      "version_requirement": ">= 3.4.0"
     }
   ],
   "operatingsystem_support": [
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [


### PR DESCRIPTION
* Add Rubocop
* Test on Puppet 4.x with Ruby 2.1
* Clean up puppet-lint rules
* Mark as supported on Debian 8
* Fix open-ended module dependencies