### PR TITLE
Break filter and nat rules out of main class and make them optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This sets up the Docker iptables rules and allows access to containers from conn
 ## Managed chains
 The module can manage all the iptables chains that Docker touches, depending on how it is configured. With more recent versions of Docker, fewer iptables rules and chains need to be managed. With older versions of Docker, this module can be used to adjust the iptables rules to match those produced by newer versions of Docker.
 
-The two parameters that control which chains are managed are the `$manage_nat_table` and `$manage_filter_table` parameters. When these are set true, the following chains will be managed:
+The two parameters that control which chains are managed are the `$manage_nat_table` and `$manage_filter_table` parameters. When these are set `true`, the following chains will be managed:
 **nat table**
 * `PREROUTING`
 * `OUTPUT`
@@ -33,7 +33,7 @@ The two parameters that control which chains are managed are the `$manage_nat_ta
 **filter table**
 * `FORWARD`
 
-By default, these parameters are false. Set true, the chains will be purged and unmanaged rules will be removed. You can adjust which rules are *not* removed using the `<chain>_purge_ignore` parameters. See the [`docker_firewall::nat`](manifests/nat.pp) and [`docker_firewall::filter`](manifests/filter.pp) classes for more information.
+By default, these parameters are `false`. Set `true`, the chains will be purged and unmanaged rules will be removed. You can adjust which rules are *not* removed using the `<chain>_purge_ignore` parameters. See the [`docker_firewall::nat`](manifests/nat.pp) and [`docker_firewall::filter`](manifests/filter.pp) classes for more information.
 
 By default, the policies of the chains will not be managed. You can use the `<chain>_policy` parameters to adjust this. The exception to this is the `filter`/`FORWARD` chain which, by default, will be set to have a policy of `DROP`. This is something the Docker daemon does since version 1.13.0. For more information see [this discussion](https://github.com/docker/docker/issues/14041).
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ class { 'docker_firewall':
 This sets up the Docker iptables rules and allows access to containers from connections incoming from the `eth1` interface, while dropping external connections from other interfaces.
 
 ## Managed chains
-The module manages all the iptables chains that Docker touches. The chains will be purged and unmanaged rules will be removed. You can adjust which rules are *not* removed using the `<chain>_purge_ignore` parameters. See the [manifest source](manifests/init.pp) for more information.
+The module can manage all the iptables chains that Docker touches, depending on how it is configured. With more recent versions of Docker, fewer iptables rules and chains need to be managed. With older versions of Docker, this module can be used to adjust the iptables rules to match those produced by newer versions of Docker.
 
-The following chains will be purged:  
+The two parameters that control which chains are managed are the `$manage_nat_table` and `$manage_filter_table` parameters. When these are set true, the following chains will be managed:
 **nat table**
 * `PREROUTING`
 * `OUTPUT`
@@ -32,6 +32,8 @@ The following chains will be purged:
 
 **filter table**
 * `FORWARD`
+
+By default, these parameters are false. Set true, the chains will be purged and unmanaged rules will be removed. You can adjust which rules are *not* removed using the `<chain>_purge_ignore` parameters. See the [`docker_firewall::nat`](manifests/nat.pp) and [`docker_firewall::filter`](manifests/filter.pp) classes for more information.
 
 By default, the policies of the chains will not be managed. You can use the `<chain>_policy` parameters to adjust this. The exception to this is the `filter`/`FORWARD` chain which, by default, will be set to have a policy of `DROP`. This is something the Docker daemon does since version 1.13.0. For more information see [this discussion](https://github.com/docker/docker/issues/14041).
 

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -1,0 +1,41 @@
+# == Class: docker_firewall::filter
+#
+# === Parameters
+#
+# [*forward_filter_purge_ignore*]
+#   A list of regexes to use when purging the OUTPUT chain in the nat table.
+#   Rules that match one or more of the regexes will not be deleted.
+#
+# [*forward_policy*]
+#   The default policy for the FORWARD chain in the filter table. The default is
+#   'drop'.
+class docker_firewall::filter (
+  Variant[String, Array[String]] $forward_purge_ignore  = $docker_firewall::forward_filter_purge_ignore,
+  Optional[String]               $forward_policy        = $docker_firewall::forward_filter_policy,
+) {
+  assert_private()
+
+  # FORWARD
+  firewallchain { 'FORWARD:filter:IPv4':
+    purge  => true,
+    ignore => $forward_purge_ignore,
+    policy => $forward_policy,
+  }
+
+  # The DOCKER-ISOLATION chain is new to Docker 1.10. Its purpose is to isolate
+  # different Docker bridge networks. Docker adds a rule as the first rule to
+  # the FORWARD chain that sends all traffic through the DOCKER-ISOLATION chain.
+  # The DOCKER-ISOLATION chain should only ever contain DROP rules so it should
+  # be safe to keep Docker's behaviour with regards to this chain.
+  # DOCKER-ISOLATION - let Docker manage this chain completely
+  firewallchain { 'DOCKER-ISOLATION:filter:IPv4':
+    ensure => present,
+  }
+  # -A FORWARD -j DOCKER-ISOLATION
+  firewall { '100 send FORWARD traffic to DOCKER-ISOLATION chain':
+    table => 'filter',
+    chain => 'FORWARD',
+    proto => 'all',
+    jump  => 'DOCKER-ISOLATION',
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,9 @@
 #   Generally, you should only need to adjust the *bridges* parameter. By
 #   default this just includes the 'docker0' bridge interface.
 #
+# [*manage_nat_table*]
+#   Whether or not to manage the chains that Docker uses in the nat table.
+#
 # [*prerouting_nat_purge_ignore*]
 #   A list of regexes to use when purging the PREROUTING chain in the nat table.
 #   Rules that match one or more of the regexes will not be deleted.
@@ -37,16 +40,20 @@
 #   A list of regexes to use when purging the POSTROUTING chain in the nat
 #   table. Rules that match one or more of the regexes will not be deleted.
 #
-# [*output_nat_policy*]
-#   The default policy for the POSTROUTING chain in the nat table. The default
-#   is 'drop'.
+# [*postrouting_nat_policy*]
+#   The default policy for the POSTROUTING chain in the nat table.
+#
+# [*manage_filter_table*]
+#   Whether or not to manage the chains that Docker uses in the filter table
+#   (currently just the FORWARD chain).
 #
 # [*forward_filter_purge_ignore*]
 #   A list of regexes to use when purging the OUTPUT chain in the nat table.
 #   Rules that match one or more of the regexes will not be deleted.
 #
-# [*output_nat_policy*]
-#   The default policy for the OUTPUT chain in the nat table.
+# [*forward_policy*]
+#   The default policy for the FORWARD chain in the filter table. The default is
+#   'drop'.
 #
 # [*accept_rules*]
 #   A hash of firewall resources to create. These rules will apply to the
@@ -54,109 +61,30 @@
 #   accepted if it is really headed for a container. All other parameters for
 #   the firewall resource can be set by the user.
 class docker_firewall (
-  Hash[String, Hash] $bridges                      = {},
-  Hash[String, Hash] $default_bridges              = {'docker0' => {}},
-
+  Boolean $manage_nat_table                                    = false,
   Variant[String, Array[String]] $prerouting_nat_purge_ignore  = [],
   Optional[String]               $prerouting_nat_policy        = undef,
   Variant[String, Array[String]] $output_nat_purge_ignore      = [],
   Optional[String]               $output_nat_policy            = undef,
   Variant[String, Array[String]] $postrouting_nat_purge_ignore = [],
   Optional[String]               $postrouting_nat_policy       = undef,
+
+  Boolean $manage_filter_table                                 = false,
   Variant[String, Array[String]] $forward_filter_purge_ignore  = [],
   Optional[String]               $forward_filter_policy        = 'drop',
 
-  Hash[String, Hash] $accept_rules = {},
+  Hash[String, Hash] $bridges                                  = {},
+  Hash[String, Hash] $default_bridges                          = {'docker0' => {}},
+
+  Hash[String, Hash] $accept_rules                             = {},
 ) {
   include firewall
 
-  # nat table
-  # =========
-
-  # PREROUTING
-  firewallchain { 'PREROUTING:nat:IPv4':
-    ensure => present,
-    purge  => true,
-    ignore => $prerouting_nat_purge_ignore,
-    policy => $prerouting_nat_policy,
+  if $manage_nat_table {
+    include docker_firewall::nat
   }
-  # -A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
-  firewall { '100 DOCKER table PREROUTING LOCAL traffic':
-    table    => 'nat',
-    chain    => 'PREROUTING',
-    dst_type => 'LOCAL',
-    proto    => 'all',
-    jump     => 'DOCKER',
-  }
-
-  # OUTPUT
-  firewallchain { 'OUTPUT:nat:IPv4':
-    ensure => present,
-    purge  => true,
-    ignore => $output_nat_purge_ignore,
-    policy => $output_nat_policy,
-  }
-  # -A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
-  firewall { '100 DOCKER chain, route LOCAL non-loopback traffic to DOCKER':
-    table       => 'nat',
-    chain       => 'OUTPUT',
-    destination => "! ${::network_lo}/8",
-    dst_type    => 'LOCAL',
-    proto       => 'all',
-    jump        => 'DOCKER',
-  }
-
-  # POSTROUTING
-  # Docker dynamically adds masquerade rules per container. These are difficult
-  # to match on accurately. This regex matches a POSTROUTING rule with identical
-  # source (-s) and destination IPv4 addresses (-d), plus some other parameters
-  # (likely to be a match on the TCP or UDP port), that jumps to the MASQUERADE
-  # action.
-  $default_postrouting_nat_purge_ignore = [
-    '^-A POSTROUTING -s (?<source>(?:[0-9]{1,3}\.){3}[0-9]{1,3})\/32 -d (\g<source>)\/32 .* -j MASQUERADE$',
-  ]
-  $_postrouting_nat_purge_ignore = $postrouting_nat_purge_ignore ? {
-    String => [$postrouting_nat_purge_ignore],
-    Array  => $postrouting_nat_purge_ignore,
-  }
-  $final_postrouting_nat_purge_ignore = concat($default_postrouting_nat_purge_ignore, $_postrouting_nat_purge_ignore)
-  firewallchain { 'POSTROUTING:nat:IPv4':
-    ensure => present,
-    purge  => true,
-    ignore => $final_postrouting_nat_purge_ignore,
-    policy => $postrouting_nat_policy,
-  }
-
-  # DOCKER - let Docker manage this chain completely
-  firewallchain { 'DOCKER:nat:IPv4':
-    ensure => present,
-  }
-
-  # filter table
-  # ============
-
-  # FORWARD
-  firewallchain { 'FORWARD:filter:IPv4':
-    purge  => true,
-    ignore => $forward_filter_purge_ignore,
-    policy => $forward_filter_policy,
-  }
-
-  # The DOCKER-ISOLATION chain is new to Docker 1.10. Its purpose is to isolate
-  # different Docker bridge networks. Docker adds a rule as the first rule to
-  # the FORWARD chain that sends all traffic through the DOCKER-ISOLATION chain.
-  # The DOCKER-ISOLATION chain should only ever contain DROP rules so it should
-  # be safe to keep Docker's behaviour with regards to this chain.
-  # DOCKER-ISOLATION - let Docker manage this chain completely
-  firewallchain { 'DOCKER-ISOLATION:filter:IPv4':
-    ensure => present,
-  }
-  # -A FORWARD -j DOCKER-ISOLATION
-  firewall { '100 send FORWARD traffic to DOCKER-ISOLATION chain':
-    table => 'filter',
-    chain => 'FORWARD',
-    proto => 'all',
-    jump  => 'DOCKER-ISOLATION',
+  if $manage_filter_table {
+    include docker_firewall::filter
   }
 
   # DOCKER - let Docker manage this chain completely

--- a/manifests/nat.pp
+++ b/manifests/nat.pp
@@ -1,0 +1,94 @@
+# == Class: docker_firewall::nat
+#
+#
+# === Parameters
+#
+# [*prerouting_purge_ignore*]
+#   A list of regexes to use when purging the PREROUTING chain in the nat table.
+#   Rules that match one or more of the regexes will not be deleted.
+#
+# [*prerouting_policy*]
+#   The default policy for the PREROUTING chain in the nat table.
+#
+# [*output_purge_ignore*]
+#   A list of regexes to use when purging the OUTPUT chain in the nat table.
+#   Rules that match one or more of the regexes will not be deleted.
+#
+# [*output_policy*]
+#   The default policy for the OUTPUT chain in the nat table.
+#
+# [*postrouting_purge_ignore*]
+#   A list of regexes to use when purging the POSTROUTING chain in the nat
+#   table. Rules that match one or more of the regexes will not be deleted.
+#
+# [*postrouting_policy*]
+#   The default policy for the POSTROUTING chain in the nat table.
+class docker_firewall::nat (
+  Variant[String, Array[String]] $prerouting_purge_ignore  = $docker_firewall::prerouting_nat_purge_ignore,
+  Optional[String]               $prerouting_policy        = $docker_firewall::prerouting_nat_policy,
+  Variant[String, Array[String]] $output_purge_ignore      = $docker_firewall::output_nat_purge_ignore,
+  Optional[String]               $output_policy            = $docker_firewall::output_nat_policy,
+  Variant[String, Array[String]] $postrouting_purge_ignore = $docker_firewall::postrouting_nat_purge_ignore,
+  Optional[String]               $postrouting_policy       = $docker_firewall::postrouting_nat_policy,
+) {
+  assert_private()
+
+  # PREROUTING
+  firewallchain { 'PREROUTING:nat:IPv4':
+    ensure => present,
+    purge  => true,
+    ignore => $prerouting_purge_ignore,
+    policy => $prerouting_policy,
+  }
+  # -A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
+  firewall { '100 DOCKER table PREROUTING LOCAL traffic':
+    table    => 'nat',
+    chain    => 'PREROUTING',
+    dst_type => 'LOCAL',
+    proto    => 'all',
+    jump     => 'DOCKER',
+  }
+
+  # OUTPUT
+  firewallchain { 'OUTPUT:nat:IPv4':
+    ensure => present,
+    purge  => true,
+    ignore => $output_purge_ignore,
+    policy => $output_policy,
+  }
+  # -A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
+  firewall { '100 DOCKER chain, route LOCAL non-loopback traffic to DOCKER':
+    table       => 'nat',
+    chain       => 'OUTPUT',
+    destination => "! ${::network_lo}/8",
+    dst_type    => 'LOCAL',
+    proto       => 'all',
+    jump        => 'DOCKER',
+  }
+
+  # POSTROUTING
+  # Docker dynamically adds masquerade rules per container. These are difficult
+  # to match on accurately. This regex matches a POSTROUTING rule with identical
+  # source (-s) and destination IPv4 addresses (-d), plus some other parameters
+  # (likely to be a match on the TCP or UDP port), that jumps to the MASQUERADE
+  # action.
+  $default_postrouting_purge_ignore = [
+    '^-A POSTROUTING -s (?<source>(?:[0-9]{1,3}\.){3}[0-9]{1,3})\/32 -d (\g<source>)\/32 .* -j MASQUERADE$',
+  ]
+  $_postrouting_purge_ignore = $postrouting_purge_ignore ? {
+    String => [$postrouting_purge_ignore],
+    Array  => $postrouting_purge_ignore,
+  }
+  $final_postrouting_purge_ignore = concat($default_postrouting_purge_ignore, $_postrouting_purge_ignore)
+  firewallchain { 'POSTROUTING:nat:IPv4':
+    ensure => present,
+    purge  => true,
+    ignore => $final_postrouting_purge_ignore,
+    policy => $postrouting_policy,
+  }
+
+  # DOCKER - let Docker manage this chain completely
+  firewallchain { 'DOCKER:nat:IPv4':
+    ensure => present,
+  }
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,22 +8,68 @@ describe 'docker_firewall' do
       it { is_expected.to compile }
 
       describe 'with default options' do
-        it do
-          is_expected.to contain_class('docker_firewall').with(
-            :prerouting_nat_purge_ignore => [],
-            :prerouting_nat_policy => nil,
-            :output_nat_purge_ignore => [],
-            :output_nat_policy => nil,
-            :postrouting_nat_purge_ignore => [],
-            :postrouting_nat_policy => nil,
-            :forward_filter_purge_ignore => [],
-            :forward_filter_policy => 'drop'
-          )
-        end
+        it { is_expected.to contain_class('docker_firewall') }
 
         it { is_expected.to contain_class('firewall') }
 
+        it do
+          is_expected.to contain_firewallchain('DOCKER:filter:IPv4')
+            .with_ensure('present')
+        end
+
+        it do
+          is_expected.to contain_firewallchain('DOCKER_INPUT:filter:IPv4')
+            .with_ensure('present')
+            .with_purge(true)
+        end
+
+        it do
+          is_expected.to contain_firewall('999 drop DOCKER_INPUT traffic')
+            .with_table('filter')
+            .with_chain('DOCKER_INPUT')
+            .with_proto('all')
+            .with_action('drop')
+        end
+
+        it do
+          is_expected.to contain_firewall(
+            '100 accept related, established traffic in DOCKER_INPUT chain'
+          ).with_table('filter')
+            .with_chain('DOCKER_INPUT')
+            .with_ctstate(['RELATED', 'ESTABLISHED'])
+            .with_proto('all')
+            .with_action('accept')
+        end
+
+        # Default docker0 bridge and associated rules
         it { is_expected.to contain_docker_firewall__bridge('docker0') }
+
+        it do
+          is_expected.to contain_firewall(
+            '102 send FORWARD traffic for docker0 to DOCKER_INPUT chain'
+          )
+        end
+
+        it do
+          is_expected.to contain_firewall(
+            '100 accept traffic from docker0 DOCKER_INPUT chain'
+          )
+        end
+      end
+
+      describe 'with manage_nat_table set true' do
+        let(:params) { {:manage_nat_table => true} }
+
+        it do
+          is_expected.to contain_class('docker_firewall::nat').with(
+            :prerouting_purge_ignore => [],
+            :prerouting_policy => nil,
+            :output_purge_ignore => [],
+            :output_policy => nil,
+            :postrouting_purge_ignore => [],
+            :postrouting_policy => nil
+          )
+        end
 
         it do
           is_expected.to contain_firewallchain('PREROUTING:nat:IPv4')
@@ -80,6 +126,24 @@ describe 'docker_firewall' do
         end
 
         it do
+          is_expected.to contain_firewall(
+            '100 DOCKER chain, MASQUERADE docker0 bridge traffic not bound to '\
+            'docker0 bridge'
+          )
+        end
+      end
+
+      describe 'with manage_filter_table set true' do
+        let(:params) { {:manage_filter_table => true} }
+
+        it do
+          is_expected.to contain_class('docker_firewall::filter').with(
+            :forward_purge_ignore => [],
+            :forward_policy => 'drop'
+          )
+        end
+
+        it do
           is_expected.to contain_firewallchain('FORWARD:filter:IPv4')
             .with_purge(true)
             .with_ignore([])
@@ -101,44 +165,23 @@ describe 'docker_firewall' do
         end
 
         it do
-          is_expected.to contain_firewallchain('DOCKER:filter:IPv4')
-            .with_ensure('present')
-        end
-
-        it do
-          is_expected.to contain_firewallchain('DOCKER_INPUT:filter:IPv4')
-            .with_ensure('present')
-            .with_purge(true)
-        end
-
-        it do
-          is_expected.to contain_firewall('999 drop DOCKER_INPUT traffic')
-            .with_table('filter')
-            .with_chain('DOCKER_INPUT')
-            .with_proto('all')
-            .with_action('drop')
-        end
-
-        it do
           is_expected.to contain_firewall(
-            '100 accept related, established traffic in DOCKER_INPUT chain'
-          ).with_table('filter')
-            .with_chain('DOCKER_INPUT')
-            .with_ctstate(['RELATED', 'ESTABLISHED'])
-            .with_proto('all')
-            .with_action('accept')
+            '101 accept docker0 traffic to other interfaces on FORWARD chain'
+          )
         end
       end
 
       describe 'with custom purge and policy parameters' do
         let(:params) do
           {
+            :manage_nat_table => true,
             :prerouting_nat_purge_ignore => ['foobar'],
             :prerouting_nat_policy => 'drop',
             :output_nat_purge_ignore => ['foobaz'],
             :output_nat_policy => 'reject',
             :postrouting_nat_purge_ignore => ['barbaz'],
             :postrouting_nat_policy => 'drop',
+            :manage_filter_table => true,
             :forward_filter_purge_ignore => ['barfoo'],
             :forward_filter_policy => 'accept'
           }
@@ -177,9 +220,11 @@ describe 'docker_firewall' do
       describe 'with custom string ignore policies' do
         let(:params) do
           {
+            :manage_nat_table => true,
             :prerouting_nat_purge_ignore => 'foobar',
             :output_nat_purge_ignore => 'foobaz',
             :postrouting_nat_purge_ignore => 'barbaz',
+            :manage_filter_table => true,
             :forward_filter_purge_ignore => 'barfoo',
           }
         end

--- a/spec/defines/bridge_spec.rb
+++ b/spec/defines/bridge_spec.rb
@@ -3,50 +3,43 @@ require 'spec_helper'
 describe 'docker_firewall::bridge' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:title) { 'docker0' }
+      let(:title) { 'mybridge' }
+      let(:facts) do
+        add_docker_iface facts, 'mybridge', :network => '172.18.0.0'
+      end
 
-      describe 'when facts are available for the interface' do
-        let(:facts) { add_docker_iface facts }
+      describe 'with docker_firewall defaults' do
+        let(:pre_condition) { 'include docker_firewall' }
 
         it do
-          is_expected.to contain_firewall(
-            '100 DOCKER chain, MASQUERADE docker0 bridge traffic not bound to '\
-            'docker0 bridge'
-          ).with_table('nat')
-            .with_chain('POSTROUTING')
-            .with_source('172.17.0.0/16')
-            .with_outiface('! docker0')
-            .with_proto('all')
-            .with_jump('MASQUERADE')
+          is_expected.not_to contain_firewall(
+            '100 DOCKER chain, MASQUERADE mybridge bridge traffic not bound '\
+            'to mybridge bridge'
+          )
+        end
+
+        it do
+          is_expected.not_to contain_firewall(
+            '101 accept mybridge traffic to other interfaces on FORWARD chain'
+          )
         end
 
         it do
           is_expected.to contain_firewall(
-            '101 accept docker0 traffic to other interfaces on FORWARD chain'
+            '102 send FORWARD traffic for mybridge to DOCKER_INPUT chain'
           ).with_table('filter')
             .with_chain('FORWARD')
-            .with_iniface('docker0')
-            .with_outiface('! docker0')
-            .with_proto('all')
-            .with_action('accept')
-        end
-
-        it do
-          is_expected.to contain_firewall(
-            '102 send FORWARD traffic for docker0 to DOCKER_INPUT chain'
-          ).with_table('filter')
-            .with_chain('FORWARD')
-            .with_outiface('docker0')
+            .with_outiface('mybridge')
             .with_proto('all')
             .with_jump('DOCKER_INPUT')
         end
 
         it do
           is_expected.to contain_firewall(
-            '100 accept traffic from docker0 DOCKER_INPUT chain'
+            '100 accept traffic from mybridge DOCKER_INPUT chain'
           ).with_table('filter')
             .with_chain('DOCKER_INPUT')
-            .with_iniface('docker0')
+            .with_iniface('mybridge')
             .with_proto('all')
             .with_action('accept')
         end
@@ -56,73 +49,78 @@ describe 'docker_firewall::bridge' do
         let(:facts) { facts }
         it do
           is_expected.not_to contain_firewall(
-            '100 DOCKER chain, MASQUERADE docker0 bridge traffic not bound to '\
-            'docker0 bridge'
+            '100 DOCKER chain, MASQUERADE mybridge bridge traffic not bound '\
+            'to mybridge bridge'
           )
         end
         it do
           is_expected.not_to contain_firewall(
-            '101 accept docker0 traffic to other interfaces on FORWARD chain'
+            '101 accept mybridge traffic to other interfaces on FORWARD chain'
           )
         end
         it do
           is_expected.not_to contain_firewall(
-            '102 send FORWARD traffic for docker0 to DOCKER_INPUT chain'
+            '102 send FORWARD traffic for mybridge to DOCKER_INPUT chain'
           )
         end
         it do
           is_expected.not_to contain_firewall(
-            '100 accept traffic from docker0 DOCKER_INPUT chain'
+            '100 accept traffic from mybridge DOCKER_INPUT chain'
           )
         end
       end
 
-      describe 'with a custom bridge interface' do
-        let(:title) { 'br-d108dbddb4c8' }
-        let(:facts) do
-          add_docker_iface facts, 'br-d108dbddb4c8', :network => '172.18.0.0'
+      describe 'docker_firewall with manage_nat_table set true' do
+        let(:pre_condition) do
+          <<-EOS
+          class { 'docker_firewall':
+            manage_nat_table => true,
+          }
+          EOS
         end
 
         it do
           is_expected.to contain_firewall(
-            '100 DOCKER chain, MASQUERADE br-d108dbddb4c8 bridge traffic not '\
-            'bound to br-d108dbddb4c8 bridge'
+            '100 DOCKER chain, MASQUERADE mybridge bridge traffic not bound '\
+            'to mybridge bridge'
           ).with_table('nat')
             .with_chain('POSTROUTING')
             .with_source('172.18.0.0/16')
-            .with_outiface('! br-d108dbddb4c8')
+            .with_outiface('! mybridge')
             .with_proto('all')
             .with_jump('MASQUERADE')
         end
 
         it do
-          is_expected.to contain_firewall(
-            '101 accept br-d108dbddb4c8 traffic to other interfaces on '\
-            'FORWARD chain'
-          ).with_table('filter')
-            .with_chain('FORWARD')
-            .with_iniface('br-d108dbddb4c8')
-            .with_outiface('! br-d108dbddb4c8')
-            .with_proto('all')
-            .with_action('accept')
+          is_expected.not_to contain_firewall(
+            '101 accept mybridge traffic to other interfaces on FORWARD chain'
+          )
+        end
+      end
+
+      describe 'docker_firewall with manage_filter_table set true' do
+        let(:pre_condition) do
+          <<-EOS
+          class { 'docker_firewall':
+            manage_filter_table => true,
+          }
+          EOS
+        end
+
+        it do
+          is_expected.not_to contain_firewall(
+            '100 DOCKER chain, MASQUERADE mybridge bridge traffic not bound '\
+            'to mybridge bridge'
+          )
         end
 
         it do
           is_expected.to contain_firewall(
-            '102 send FORWARD traffic for br-d108dbddb4c8 to DOCKER_INPUT chain'
+            '101 accept mybridge traffic to other interfaces on FORWARD chain'
           ).with_table('filter')
             .with_chain('FORWARD')
-            .with_outiface('br-d108dbddb4c8')
-            .with_proto('all')
-            .with_jump('DOCKER_INPUT')
-        end
-
-        it do
-          is_expected.to contain_firewall(
-            '100 accept traffic from br-d108dbddb4c8 DOCKER_INPUT chain'
-          ).with_table('filter')
-            .with_chain('DOCKER_INPUT')
-            .with_iniface('br-d108dbddb4c8')
+            .with_iniface('mybridge')
+            .with_outiface('! mybridge')
             .with_proto('all')
             .with_action('accept')
         end


### PR DESCRIPTION
The plan here is to make it more optional to manage some rules with Puppet.

Managing the `nat` table is almost always unnecessary. Managing the `filter` table should only be necessary with older versions of Docker (once I've made some other changes after this).