### PR TITLE
Move to a blacklist-based system closer to that recommended by Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,89 @@
 # puppet-docker_firewall
+
+> NOTE: There have been some significant changes to how this module works between each major point release. We've changed our minds a lot (and so has Docker). We recommend that you pin the version of this module you use and read this README thoroughly before upgrading.
+
 Puppet module for simplifying the management of iptables rules when running Docker
 
 Docker makes extensive use of iptables to enable features like port-forwarding and inter-container communication when using bridge-mode networking. Unfortunately, the way Docker configures iptables makes it difficult to limit access to containers from the outside world.
 
-The `docker_firewall` class aims to make running custom iptables rules alongside Docker easier. It manages the static iptables rules that Docker creates when its daemon starts and allows Docker to dynamically create rules as containers are started.
+The `docker_firewall` class aims to make running custom iptables rules alongside Docker easier. It (optionally) manages the static iptables rules that Docker creates when its daemon starts and allows Docker to dynamically create rules as containers are started.
 
 ***Please read all of this document if it is important to you that your containers cannot be accessed from the outside world.***
 
 ## Usage
 ```puppet
 class { 'docker_firewall':
-  accept_rules => {
-    '200 accept eth1 traffic' => {
-      'iniface' => 'eth1',
+  drop_rules => {
+    '200 drop eth0 traffic' => {
+      'iniface' => 'eth0',
       'proto'   => 'all',
     },
   },
-  subscribe    => Service['docker'],
+  subscribe  => Service['docker'],
 }
 ```
-This sets up the Docker iptables rules and allows access to containers from connections incoming from the `eth1` interface, while dropping external connections from other interfaces.
+This sets up the Docker iptables rules and blocks access to containers from connections incoming from the `eth0` interface, while allowing external connections from other interfaces.
 
 ## Managed chains
 The module can manage all the iptables chains that Docker touches, depending on how it is configured. With more recent versions of Docker, fewer iptables rules and chains need to be managed. With older versions of Docker, this module can be used to adjust the iptables rules to match those produced by newer versions of Docker.
 
-The two parameters that control which chains are managed are the `$manage_nat_table` and `$manage_filter_table` parameters. When these are set `true`, the following chains will be managed:
-**nat table**
+The two boolean parameters that control which chains are managed are the `$manage_nat_table` and `$manage_filter_table` parameters. Both default to `false`, but may need to be adjusted depending on the version of Docker you are using:
+* `$manage_nat_table` can be set `true` with any version of Docker but should only be used if you want Puppet to manage as many of Docker's iptables rules as possible.
+* `$manage_filter_table` **must be set `true` with versions of Docker less than 17.04.0** in order for this firewall setup to work correctly. It can also be set `true` for newer Docker versions if you would like Puppet to manage as many of Docker's iptables rules as possible.
+
+> In general, we would recommend letting the Docker daemon manage as many of its own rules as possible. The dynamic manipulation of iptables rules by the Docker daemon is not really compatible with the model of static rules that the Puppet firewall module was designed around.
+
+When these parameters are set `true`, the following chains will be managed:
+##### `$manage_nat_table`: nat table
 * `PREROUTING`
 * `OUTPUT`
 * `POSTROUTING`
 
-**filter table**
+##### `$manage_filter_table`: filter table
 * `FORWARD`
 
-By default, these parameters are `false`. Set `true`, the chains will be purged and unmanaged rules will be removed. You can adjust which rules are *not* removed using the `<chain>_purge_ignore` parameters. See the [`docker_firewall::nat`](manifests/nat.pp) and [`docker_firewall::filter`](manifests/filter.pp) classes for more information.
+When these parameters are set `true`, the chains will be purged and unmanaged rules will be removed. You can adjust which rules are *not* removed using the `<chain>_purge_ignore` parameters. See the [`docker_firewall::nat`](manifests/nat.pp) and [`docker_firewall::filter`](manifests/filter.pp) classes for more information.
 
 By default, the policies of the chains will not be managed. You can use the `<chain>_policy` parameters to adjust this. The exception to this is the `filter`/`FORWARD` chain which, by default, will be set to have a policy of `DROP`. This is something the Docker daemon does since version 1.13.0. For more information see [this discussion](https://github.com/docker/docker/issues/14041).
 
 In addition, the `DOCKER` chain in the nat table and the `DOCKER` and `DOCKER-ISOLATION` chains in the filter table are managed but not purged. Rules in these chains are created by the Docker daemon and should not be changed.
 
 ## `DOCKER_INPUT` chain
-The major functionality of the class (limiting outside connections to containers) works by adding a chain called `DOCKER_INPUT` that handles connections destined for the `docker0` interface. This chain can be used much like the `INPUT` chain in the filter table would typically be used to whitelist connections, but instead of `ACCEPT`-ing connections, rather jump to the `DOCKER` chain.
+The major functionality of the class (limiting outside connections to containers) works by adding a chain called `DOCKER_INPUT` that handles all connections before they pass through the `DOCKER` chain.
 
-For example, for a regular input rule that allows connections from
-`192.168.0.1` you could do something like:
-```
--A INPUT -s 192.168.0.1/32 -j ACCEPT
-```
-To allow access to Docker containers you would do:
-```
--A DOCKER_INPUT -s 192.168.0.1/32 -j DOCKER
+This works by injecting a rule into the front of the `DOCKER` chain that jumps to the `DOCKER_INPUT` chain. This is the only method recommended by Docker for limiting access to containers and is briefly mentioned in the documentation [here](https://docs.docker.com/engine/userguide/networking/default_network/container-communication/#communicating-to-the-outside-world).
+
+The `DOCKER_INPUT` chain works as a blacklist for connections. Users should add rules to the `DOCKER_INPUT` chain that either `DROP` unwanted packets, or `RETURN` acceptable packets to the `DOCKER` chain. For example:
+```puppet
+firewall { '300 allow eth0 access from trusted address':
+  chain   => 'DOCKER_INPUT',
+  iniface => 'eth0',
+  source  => '216.58.223.3/32',
+  action  => 'return',
+}
+
+firewall { '999 drop all incoming eth0 connections':
+  chain   => 'DOCKER_INPUT',
+  iniface => 'eth0',
+  proto   => 'all',
+  action  => 'drop',
+}
 ```
 
-The `$accept_rules` parameter for the main `docker_firewall` class provides an easy way to set up rules to accept connections to Docker containers. This parameter takes a hash of `firewall` resources to create, and defaults those rules to be in the `DOCKER_INPUT` chain and jump to the `DOCKER` chain. This parameter is probably best set using Hiera, for example:
+For convenience, the `docker_firewall` class provides the `$drop_rules` and `$accept_rules` parameters that take hashes of `firewall` resources with the correct `chain` and `action` parameters set to either drop or accept (return) packets. Doing the equivalent of the above Puppet code in Hiera would look like this:
 ```yaml
 docker_firewall::accept_rules:
-  200 accept all traffic from 192.168.0.1/32:
-    source: 192.168.0.1/32
+  300 allow eth0 access from trusted address:
+    iniface: eth0
+    source: 216.58.223.3/32
+
+docker_firewall::drop_rules:
+  999 drop all incoming eth0 connections:
+    iniface: eth0
     proto: all
 ```
+
+**NOTE** that the default is to accept packets (this is a blacklist system). Accept rules without a **corresponding drop rule that appears later in the chain** will have no effect.
 
 ## Docker daemon restarts
 This class should be used in combination with the `--iptables=true` flag (the default) when starting the Docker daemon. We *want* Docker to manage iptables rules for each container.
@@ -69,10 +94,12 @@ This means that when the Docker daemon restarts there may be some time before th
 
 You should ensure that the `docker_firewall` class always runs after the Docker service restarts.
 
-## Facter and the `docker0` interface
-Using this module at the same time as you install Docker may require a second run of Puppet as Facter will need a chance to pick up details about Docker's bridge interface (`docker0`). In order to set up the firewall, the `$::network_docker0` fact must be set.
+## Facter and Docker's bridge interfaces
+Using this module at the same time as you install Docker may require a second run of Puppet if `$manage_nat_table` is `true`. Facter will need another run to pick up details about Docker's bridge interfaces (e.g. `docker0`) if an interface was created during the current Puppet run. In order to set up the firewall rules for the nat table, the `$::network_<bridge-name>` (e.g. `$::network_docker0`) fact must be set.
 
 ## Custom bridge interfaces
+> NOTE: Defining `docker_firewall::bridge` resources is only necessary if either of the `$manage_nat_table` or `$manage_filter_table` parameters for the `docker_firewall` class are `true`. When both are `false`, `bridge` resources do nothing.
+
 When setting up a custom Docker bridge network (available since Docker 1.9.0), extra iptables rules are needed for each network. It's possible to define extra bridge interfaces using the `$bridges` parameter for the `docker_firewall` class or by defining `docker_firewall::bridge` resources.
 
 **NOTE:** You must specify the _actual_ bridge interface name when creating the network, for example:

--- a/manifests/bridge.pp
+++ b/manifests/bridge.pp
@@ -3,8 +3,8 @@
 # Set up firewall rules specifically for a certain bridge interface. The bridge
 # interface name should be the title (or name) of the resource.
 define docker_firewall::bridge () {
-  if has_interface_with($name) {
-    if $docker_firewall::manage_nat_table {
+  if $docker_firewall::manage_nat_table {
+    if has_interface_with($name) {
       # -A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
       $source = getvar("::network_${name}")
       firewall { "100 DOCKER chain, MASQUERADE ${name} bridge traffic not bound to ${name} bridge":
@@ -15,51 +15,51 @@ define docker_firewall::bridge () {
         proto    => 'all',
         jump     => 'MASQUERADE',
       }
-
-      # TODO: additional MASQUERADE rule if --userland-proxy=false
+    } else {
+      warning("The ${name} interface has not been detected by Facter yet. You \
+        may need to re-run Puppet and/or ensure that the Docker service is \
+        started.")
     }
 
-    if $docker_firewall::manage_filter_table {
-      # These are the static firewall rules that the Docker daemon sets up for
-      # bridge networks with default settings as of Docker 17.05.0.
-      firewall {
-        default:
-          table => 'filter',
-          chain => 'FORWARD';
+    # TODO: additional MASQUERADE rule if --userland-proxy=false
+  }
 
-        # -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-        # Changed order in Docker 17.04.0:
-        # https://github.com/docker/libnetwork/pull/961
-        "200 accept related, established traffic destined for ${name}":
-          outiface => $name,
-          ctstate  => ['RELATED', 'ESTABLISHED'],
-          proto    => 'all',
-          action   => 'accept';
+  if $docker_firewall::manage_filter_table {
+    # These are the static firewall rules that the Docker daemon sets up for
+    # bridge networks with default settings as of Docker 17.05.0.
+    firewall {
+      default:
+        table => 'filter',
+        chain => 'FORWARD';
 
-        # -A FORWARD -o docker0 -j DOCKER
-        "201 forward traffic destined for ${name} to the DOCKER chain":
-          outiface => $name,
-          proto    => 'all',
-          jump     => 'DOCKER';
+      # -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+      # Changed order in Docker 17.04.0:
+      # https://github.com/docker/libnetwork/pull/961
+      "200 accept related, established traffic destined for ${name}":
+        outiface => $name,
+        ctstate  => ['RELATED', 'ESTABLISHED'],
+        proto    => 'all',
+        action   => 'accept';
 
-        # -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
-        "202 accept traffic originating from ${name} not destined for ${name}":
-          iniface  => $name,
-          outiface => "! ${name}",
-          proto    => 'all',
-          action   => 'accept';
+      # -A FORWARD -o docker0 -j DOCKER
+      "201 forward traffic destined for ${name} to the DOCKER chain":
+        outiface => $name,
+        proto    => 'all',
+        jump     => 'DOCKER';
 
-        # -A FORWARD -i docker0 -o docker0 -j ACCEPT
-        "203 accept traffic originating from ${name} destined for ${name}":
-          iniface  => $name,
-          outiface => $name,
-          proto    => 'all',
-          action   => 'accept';
-      }
+      # -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
+      "202 accept traffic originating from ${name} not destined for ${name}":
+        iniface  => $name,
+        outiface => "! ${name}",
+        proto    => 'all',
+        action   => 'accept';
+
+      # -A FORWARD -i docker0 -o docker0 -j ACCEPT
+      "203 accept traffic originating from ${name} destined for ${name}":
+        iniface  => $name,
+        outiface => $name,
+        proto    => 'all',
+        action   => 'accept';
     }
-  } else {
-    warning("The ${name} interface has not been detected by Facter yet. You \
-      may need to re-run Puppet and/or ensure that the Docker service is \
-      started.")
   }
 }

--- a/manifests/bridge.pp
+++ b/manifests/bridge.pp
@@ -20,33 +20,42 @@ define docker_firewall::bridge () {
     }
 
     if $docker_firewall::manage_filter_table {
-      # -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
-      firewall { "101 accept ${name} traffic to other interfaces on FORWARD chain":
-        table    => 'filter',
-        chain    => 'FORWARD',
-        iniface  => $name,
-        outiface => "! ${name}",
-        proto    => 'all',
-        action   => 'accept',
+      # These are the static firewall rules that the Docker daemon sets up for
+      # bridge networks with default settings as of Docker 17.05.0.
+      firewall {
+        default:
+          table => 'filter',
+          chain => 'FORWARD';
+
+        # -A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+        # Changed order in Docker 17.04.0:
+        # https://github.com/docker/libnetwork/pull/961
+        "200 accept related, established traffic destined for ${name}":
+          outiface => $name,
+          ctstate  => ['RELATED', 'ESTABLISHED'],
+          proto    => 'all',
+          action   => 'accept';
+
+        # -A FORWARD -o docker0 -j DOCKER
+        "201 forward traffic destined for ${name} to the DOCKER chain":
+          outiface => $name,
+          proto    => 'all',
+          jump     => 'DOCKER';
+
+        # -A FORWARD -i docker0 ! -o docker0 -j ACCEPT
+        "202 accept traffic originating from ${name} not destined for ${name}":
+          iniface  => $name,
+          outiface => "! ${name}",
+          proto    => 'all',
+          action   => 'accept';
+
+        # -A FORWARD -i docker0 -o docker0 -j ACCEPT
+        "203 accept traffic originating from ${name} destined for ${name}":
+          iniface  => $name,
+          outiface => $name,
+          proto    => 'all',
+          action   => 'accept';
       }
-    }
-
-    # -A FORWARD -o docker0 -j DOCKER_INPUT
-    firewall { "102 send FORWARD traffic for ${name} to DOCKER_INPUT chain":
-      table    => 'filter',
-      chain    => 'FORWARD',
-      outiface => $name,
-      proto    => 'all',
-      jump     => 'DOCKER_INPUT',
-    }
-
-    # -A DOCKER_INPUT -i docker0 -j ACCEPT
-    firewall { "100 accept traffic from ${name} DOCKER_INPUT chain":
-      table   => 'filter',
-      chain   => 'DOCKER_INPUT',
-      iniface => $name,
-      proto   => 'all',
-      action  => 'accept',
     }
   } else {
     warning("The ${name} interface has not been detected by Facter yet. You \

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "praekeltfoundation-docker_firewall",
-  "version": "0.2.1-dev",
+  "version": "0.3.0-dev",
   "author": "Jamie Hewland",
   "summary": "Simplifies management of iptables rules when running Docker",
   "license": "BSD-3-Clause",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -27,12 +27,13 @@ describe 'docker_firewall' do
           is_expected.to contain_exec(
             'inject iptables rule to jump from DOCKER to DOCKER_INPUT chain'
           ).with_command(
-            'iptables -D DOCKER -j DOCKER_INPUT; iptables -I DOCKER -j '\
-            'DOCKER_INPUT'
+            'iptables -D DOCKER -m comment --comment "Managed by Puppet" -j '\
+            'DOCKER_INPUT; iptables -I DOCKER -m comment --comment "Managed '\
+            'by Puppet" -j DOCKER_INPUT'
           ).with_path(['/usr/bin', '/sbin', '/bin'])
             .with_unless(
-              "[ \"$(iptables -S DOCKER | grep -m1 '^-A')\" = '-A DOCKER -j "\
-              "DOCKER_INPUT' ]"
+              '[ "$(iptables -S DOCKER | grep -m1 \'^-A\')" = \'-A DOCKER -m '\
+              'comment --comment "Managed by Puppet" -j DOCKER_INPUT\' ]'
             ).that_requires(
               [
                 'Firewallchain[DOCKER:filter:IPv4]',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -24,37 +24,24 @@ describe 'docker_firewall' do
         end
 
         it do
-          is_expected.to contain_firewall('999 drop DOCKER_INPUT traffic')
-            .with_table('filter')
-            .with_chain('DOCKER_INPUT')
-            .with_proto('all')
-            .with_action('drop')
+          is_expected.to contain_exec(
+            'inject iptables rule to jump from DOCKER to DOCKER_INPUT chain'
+          ).with_command(
+            'iptables -D DOCKER -j DOCKER_INPUT; iptables -I DOCKER -j '\
+            'DOCKER_INPUT'
+          ).with_path(['/usr/bin', '/sbin', '/bin'])
+            .with_unless(
+              "[ \"$(iptables -S DOCKER | grep -m1 '^-A')\" = '-A DOCKER -j "\
+              "DOCKER_INPUT' ]"
+            ).that_requires(
+              [
+                'Firewallchain[DOCKER:filter:IPv4]',
+                'Firewallchain[DOCKER_INPUT:filter:IPv4]'
+              ]
+            )
         end
 
-        it do
-          is_expected.to contain_firewall(
-            '100 accept related, established traffic in DOCKER_INPUT chain'
-          ).with_table('filter')
-            .with_chain('DOCKER_INPUT')
-            .with_ctstate(['RELATED', 'ESTABLISHED'])
-            .with_proto('all')
-            .with_action('accept')
-        end
-
-        # Default docker0 bridge and associated rules
         it { is_expected.to contain_docker_firewall__bridge('docker0') }
-
-        it do
-          is_expected.to contain_firewall(
-            '102 send FORWARD traffic for docker0 to DOCKER_INPUT chain'
-          )
-        end
-
-        it do
-          is_expected.to contain_firewall(
-            '100 accept traffic from docker0 DOCKER_INPUT chain'
-          )
-        end
       end
 
       describe 'with manage_nat_table set true' do
@@ -166,7 +153,26 @@ describe 'docker_firewall' do
 
         it do
           is_expected.to contain_firewall(
-            '101 accept docker0 traffic to other interfaces on FORWARD chain'
+            '200 accept related, established traffic destined for docker0'
+          )
+        end
+
+        it do
+          is_expected.to contain_firewall(
+            '201 forward traffic destined for docker0 to the DOCKER chain'
+          )
+        end
+
+        it do
+          is_expected.to contain_firewall(
+            '202 accept traffic originating from docker0 not destined for '\
+            'docker0'
+          )
+        end
+
+        it do
+          is_expected.to contain_firewall(
+            '203 accept traffic originating from docker0 destined for docker0'
           )
         end
       end
@@ -256,11 +262,11 @@ describe 'docker_firewall' do
         end
       end
 
-      describe 'when a custom accept rule is provided' do
+      describe 'when a custom drop rule is provided' do
         let(:params) do
           {
-            :accept_rules => {
-              '200 accept port 5000 tcp traffic' => {
+            :drop_rules => {
+              '200 drop port 5000 tcp traffic' => {
                 'dport' => 5000,
                 'proto' => 'tcp',
               }
@@ -269,12 +275,12 @@ describe 'docker_firewall' do
         end
 
         it do
-          is_expected.to contain_firewall('200 accept port 5000 tcp traffic')
+          is_expected.to contain_firewall('200 drop port 5000 tcp traffic')
             .with_dport(5000)
             .with_proto('tcp')
             .with_table('filter')
             .with_chain('DOCKER_INPUT')
-            .with_jump('DOCKER')
+            .with_action('drop')
         end
       end
 

--- a/spec/defines/bridge_spec.rb
+++ b/spec/defines/bridge_spec.rb
@@ -44,32 +44,7 @@ describe 'docker_firewall::bridge' do
         end
       end
 
-      describe 'when facts are not available for the interface' do
-        let(:facts) { facts }
-        it do
-          is_expected.not_to contain_firewall(
-            '100 DOCKER chain, MASQUERADE mybridge bridge traffic not bound '\
-            'to mybridge bridge'
-          )
-        end
-        it do
-          is_expected.not_to contain_firewall(
-            '101 accept mybridge traffic to other interfaces on FORWARD chain'
-          )
-        end
-        it do
-          is_expected.not_to contain_firewall(
-            '102 send FORWARD traffic for mybridge to DOCKER_INPUT chain'
-          )
-        end
-        it do
-          is_expected.not_to contain_firewall(
-            '100 accept traffic from mybridge DOCKER_INPUT chain'
-          )
-        end
-      end
-
-      describe 'docker_firewall with manage_nat_table set true' do
+      context 'docker_firewall with manage_nat_table set true' do
         let(:pre_condition) do
           <<-EOS
           class { 'docker_firewall':
@@ -88,6 +63,16 @@ describe 'docker_firewall::bridge' do
             .with_outiface('! mybridge')
             .with_proto('all')
             .with_jump('MASQUERADE')
+        end
+
+        describe 'when facts are not available for the interface' do
+          let(:facts) { facts }
+          it do
+            is_expected.not_to contain_firewall(
+              '100 DOCKER chain, MASQUERADE mybridge bridge traffic not bound '\
+              'to mybridge bridge'
+            )
+          end
         end
       end
 


### PR DESCRIPTION
* Not so much a recommendation as a small footnote in the docs.
* Jump to the DOCKER_INPUT chain from the DOCKER chain rather than
  the FORWARD chain. Do so using an exec rather than a firewall rule.
* Use Docker's default filter/FORWARD rules (as of 17.04/17.05 release)
  rather than our own.
* Advise managing as few of Docker's iptables rules as possible with Puppet
* Add lots of notes